### PR TITLE
ref(service_broker): fetch Github credentials from the environment

### DIFF
--- a/service_broker/Makefile
+++ b/service_broker/Makefile
@@ -1,0 +1,10 @@
+DOCKER_REPO ?= quay.io/
+DOCKER_USER ?= deis
+DOCKER_VERSION ?= latest
+
+DOCKER_IMAGE ?= ${DOCKER_REPO}${DOCKER_ORG}/cloudfoundry-github-service-broker:${VERSION}
+
+docker-build:
+	docker build -t ${DOCKER_IMAGE} .
+docker-push:
+	docker push ${DOCKER_IMAGE}

--- a/service_broker/config/settings.yml
+++ b/service_broker/config/settings.yml
@@ -30,11 +30,3 @@ catalog:
 basic_auth:
   username: admin
   password: password
-
-# credentials for broker to authenticate with the GitHub account
-github:
-  # An access token is used in place of username/password to access your GitHub account.
-  # To generate an access token run the following command then copy the value of "token" from the response.
-  # curl -u <your-github-username> -d '{"scopes": ["repo", "delete_repo"], "note": "CF Service Broker"}' https://api.github.com/authorizations
-  username: <%= ENV['GITHUB_USER_NAME'] %>
-  access_token: <%= ENV['GITHUB_TOKEN'] %>

--- a/service_broker/service_broker_app.rb
+++ b/service_broker/service_broker_app.rb
@@ -119,7 +119,8 @@ class ServiceBrokerApp < Sinatra::Base
   end
 
   def github_service
-    github_credentials = self.class.app_settings.fetch("github")
-    GithubServiceHelper.new(github_credentials.fetch("username"), github_credentials.fetch("access_token"))
+    gh_user = ENV["GITHUB_USER"]
+    gh_token = ENV["GITHUB_TOKEN"]
+    GithubServiceHelper.new(gh_user, gh_token)
   end
 end

--- a/service_broker/service_broker_app.rb
+++ b/service_broker/service_broker_app.rb
@@ -119,8 +119,6 @@ class ServiceBrokerApp < Sinatra::Base
   end
 
   def github_service
-    gh_user = ENV["GITHUB_USER"]
-    gh_token = ENV["GITHUB_TOKEN"]
-    GithubServiceHelper.new(gh_user, gh_token)
+    GithubServiceHelper.new(ENV["GITHUB_USER"], ENV["GITHUB_TOKEN"])
   end
 end


### PR DESCRIPTION
This patch makes the server slightly more in-line with 12-factor methodologies. Also, since the GitHub access token is one of the more sensitive configuration values, this is a good place to start
